### PR TITLE
Fix interval cleanup in Vanta background component

### DIFF
--- a/src/components/UI/VantaBirdsComponent.tsx
+++ b/src/components/UI/VantaBirdsComponent.tsx
@@ -13,9 +13,11 @@ export const VantaBackground: React.FC = () => {
   const vantaEffect = useRef<{ destroy: () => void } | null>(null);
 
   useEffect(() => {
+    let interval: ReturnType<typeof setInterval> | undefined;
+
     if (typeof window !== "undefined" && backgroundRef.current) {
       // Poll until the script has attached VANTA to window
-      const interval = setInterval(() => {
+      interval = setInterval(() => {
         if (window.VANTA?.BIRDS) {
           vantaEffect.current = window.VANTA.BIRDS({
             el: backgroundRef.current,
@@ -43,7 +45,11 @@ export const VantaBackground: React.FC = () => {
         }
       }, 100);
     }
+
     return () => {
+      if (interval) {
+        clearInterval(interval);
+      }
       if (vantaEffect.current) {
         vantaEffect.current.destroy();
       }


### PR DESCRIPTION
## Summary
- ensure Vanta background interval cleared and effect destroyed on unmount

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f93f285248327b0f92df5f3f25820