### PR TITLE
Add about, skills, and experience sections to portfolio

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -137,10 +137,9 @@ const Page: React.FC = () => {
             <h2 className="text-center mb-4">About Me</h2>
             <p className="lead text-center">
               I&apos;m a software developer with a completed degree in Software
-              Development from MOLK Education. For the past three months, I&apos;ve
-              been contributing at Unitech, applying workflow pipeline
-              automation and full-stack skills to deliver efficient,
-              user-focused applications.
+              Development from MOLK Education. I currently partner with
+              UnitechUSA as a client, building data-driven tools and automating
+              supply chain workflows across LATAM.
             </p>
           </Col>
         </Row>
@@ -170,6 +169,12 @@ const Page: React.FC = () => {
               <li className="list-inline-item badge bg-success m-1">Git &amp; GitHub</li>
               <li className="list-inline-item badge bg-success m-1">Agile Collaboration</li>
             </ul>
+            <h5 className="text-center mt-4">Operational Skills</h5>
+            <ul className="list-unstyled text-center">
+              <li>Automate supply chain &amp; order tracking across LATAM vendors</li>
+              <li>Cut repetitive work by up to 80% with ExcelScripts &amp; Python Playwright bots</li>
+              <li>Clarify data with advanced Excel formulas and multilingual client emails</li>
+            </ul>
           </Col>
         </Row>
         <Row id="experience" className="pt-5">
@@ -178,11 +183,12 @@ const Page: React.FC = () => {
           </Col>
           <Col md={8} className="mx-auto">
             <div className="mb-4">
-              <h5 className="fw-bold">Unitech – Software Developer</h5>
+              <h5 className="fw-bold">UnitechUSA (Client) – Operations Support Specialist</h5>
               <p className="mb-1 text-muted">Feb 2025 – Present | Remote</p>
               <p>
-                Streamline development by automating workflow pipelines and
-                collaborating across teams to deliver reliable features.
+                Eliminated manual supply chain tracking by scripting vendor
+                checks and Excel flags, saving 80% of repetitive work and
+                keeping POs and SOs accurate across regions.
               </p>
             </div>
             <div className="mb-4">
@@ -191,29 +197,9 @@ const Page: React.FC = () => {
               </h5>
               <p className="mb-1 text-muted">Jan 2025 – May 2025 | Remote</p>
               <p>
-                Contributed to a modern SaaS recruitment platform using React,
-                TypeScript, and Bootstrap, enhancing UI responsiveness and
-                collaborating through Agile practices.
-              </p>
-            </div>
-            <div className="mb-4">
-              <h5 className="fw-bold">
-                Assurant – IT Support & Troubleshooting Specialist
-              </h5>
-              <p className="mb-1 text-muted">Sep 2024 – Jan 2025 | Houston, TX</p>
-              <p>
-                Resolved support tickets with high customer satisfaction and
-                documented internal knowledge, reducing repeat issues.
-              </p>
-            </div>
-            <div className="mb-4">
-              <h5 className="fw-bold">
-                WeTeachIT – Software Development Engineering Intern
-              </h5>
-              <p className="mb-1 text-muted">Apr 2024 – Jun 2024 | Remote</p>
-              <p>
-                Built GUI automation tools with Python and Selenium, delivering
-                secure backend components and reducing login time.
+                Solved clunky recruiter workflows by building responsive
+                React/TypeScript components for a SaaS hiring platform and
+                collaborating through Agile sprints.
               </p>
             </div>
           </Col>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -45,16 +45,16 @@ const Page: React.FC = () => {
               <Nav.Link href="#home" className="fw-bold">
                 Home
               </Nav.Link>
-              <Nav.Link href="#features">About Me</Nav.Link>
-              <Nav.Link href="#pricing">Skills</Nav.Link>
-              <Nav.Link href="#pricing">Portfolio</Nav.Link>
-              <Nav.Link href="#pricing">Contact</Nav.Link>
+              <Nav.Link href="#about">About</Nav.Link>
+              <Nav.Link href="#skills">Skills</Nav.Link>
+              <Nav.Link href="#experience">Experience</Nav.Link>
+              <Nav.Link href="#contact">Contact</Nav.Link>
             </Nav>
           </Container>
         </Container>
       </Navbar>
 
-      <Container>
+      <Container id="home">
         <Row>
           <Col
             xs={12}
@@ -127,6 +127,89 @@ const Page: React.FC = () => {
                 Contact Me
               </Button>
             </Container>
+          </Col>
+        </Row>
+      </Container>
+
+      <Container id="about" className="py-5">
+        <Row className="justify-content-center">
+          <Col md={8}>
+            <h2 className="text-center mb-4">About Me</h2>
+            <p className="lead text-center">
+              I&apos;m a software developer pursuing a technical degree in Software
+              Development at MOLK Education. I enjoy building responsive,
+              user-focused applications and learning new technologies.
+            </p>
+          </Col>
+        </Row>
+      </Container>
+
+      <Container id="skills" className="py-5 bg-light rounded">
+        <Row>
+          <Col>
+            <h2 className="text-center mb-4">Skills</h2>
+            <ul className="list-inline text-center">
+              <li className="list-inline-item badge bg-success m-1">Java</li>
+              <li className="list-inline-item badge bg-success m-1">Python</li>
+              <li className="list-inline-item badge bg-success m-1">JavaScript</li>
+              <li className="list-inline-item badge bg-success m-1">TypeScript</li>
+              <li className="list-inline-item badge bg-success m-1">React</li>
+              <li className="list-inline-item badge bg-success m-1">Next.js</li>
+              <li className="list-inline-item badge bg-success m-1">Node.js</li>
+              <li className="list-inline-item badge bg-success m-1">Express</li>
+              <li className="list-inline-item badge bg-success m-1">SQL</li>
+              <li className="list-inline-item badge bg-success m-1">C#</li>
+            </ul>
+          </Col>
+        </Row>
+        <Row id="experience" className="pt-5">
+          <Col>
+            <h2 className="text-center mb-4">Experience</h2>
+          </Col>
+          <Col md={8} className="mx-auto">
+            <div className="mb-4">
+              <h5 className="fw-bold">
+                Cruitify – Software Development Engineering Intern
+              </h5>
+              <p className="mb-1 text-muted">Jan 2025 – May 2025 | Remote</p>
+              <p>
+                Contributed to a modern SaaS recruitment platform using React,
+                TypeScript, and Bootstrap, enhancing UI responsiveness and
+                collaborating through Agile practices.
+              </p>
+            </div>
+            <div className="mb-4">
+              <h5 className="fw-bold">
+                Assurant – IT Support & Troubleshooting Specialist
+              </h5>
+              <p className="mb-1 text-muted">Sep 2024 – Jan 2025 | Houston, TX</p>
+              <p>
+                Resolved support tickets with high customer satisfaction and
+                documented internal knowledge, reducing repeat issues.
+              </p>
+            </div>
+            <div className="mb-4">
+              <h5 className="fw-bold">
+                WeTeachIT – Software Development Engineering Intern
+              </h5>
+              <p className="mb-1 text-muted">Apr 2024 – Jun 2024 | Remote</p>
+              <p>
+                Built GUI automation tools with Python and Selenium, delivering
+                secure backend components and reducing login time.
+              </p>
+            </div>
+          </Col>
+        </Row>
+      </Container>
+
+      <Container id="contact" className="py-5">
+        <Row className="justify-content-center">
+          <Col md={6} className="text-center">
+            <h2 className="mb-4">Contact</h2>
+            <p>
+              Let&apos;s build something together! Reach me at
+              <a href="mailto:xerikperez@gmail.com"> xerikperez@gmail.com</a>.
+            </p>
           </Col>
         </Row>
       </Container>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -136,9 +136,11 @@ const Page: React.FC = () => {
           <Col md={8}>
             <h2 className="text-center mb-4">About Me</h2>
             <p className="lead text-center">
-              I&apos;m a software developer pursuing a technical degree in Software
-              Development at MOLK Education. I enjoy building responsive,
-              user-focused applications and learning new technologies.
+              I&apos;m a software developer with a completed degree in Software
+              Development from MOLK Education. For the past three months, I&apos;ve
+              been contributing at Unitech, applying workflow pipeline
+              automation and full-stack skills to deliver efficient,
+              user-focused applications.
             </p>
           </Col>
         </Row>
@@ -148,6 +150,7 @@ const Page: React.FC = () => {
         <Row>
           <Col>
             <h2 className="text-center mb-4">Skills</h2>
+            <h5 className="text-center">Languages &amp; Frameworks</h5>
             <ul className="list-inline text-center">
               <li className="list-inline-item badge bg-success m-1">Java</li>
               <li className="list-inline-item badge bg-success m-1">Python</li>
@@ -160,6 +163,13 @@ const Page: React.FC = () => {
               <li className="list-inline-item badge bg-success m-1">SQL</li>
               <li className="list-inline-item badge bg-success m-1">C#</li>
             </ul>
+            <h5 className="text-center mt-4">Workflow &amp; Tools</h5>
+            <ul className="list-inline text-center">
+              <li className="list-inline-item badge bg-success m-1">Workflow Pipeline Automation</li>
+              <li className="list-inline-item badge bg-success m-1">CI/CD</li>
+              <li className="list-inline-item badge bg-success m-1">Git &amp; GitHub</li>
+              <li className="list-inline-item badge bg-success m-1">Agile Collaboration</li>
+            </ul>
           </Col>
         </Row>
         <Row id="experience" className="pt-5">
@@ -167,6 +177,14 @@ const Page: React.FC = () => {
             <h2 className="text-center mb-4">Experience</h2>
           </Col>
           <Col md={8} className="mx-auto">
+            <div className="mb-4">
+              <h5 className="fw-bold">Unitech – Software Developer</h5>
+              <p className="mb-1 text-muted">Feb 2025 – Present | Remote</p>
+              <p>
+                Streamline development by automating workflow pipelines and
+                collaborating across teams to deliver reliable features.
+              </p>
+            </div>
             <div className="mb-4">
               <h5 className="fw-bold">
                 Cruitify – Software Development Engineering Intern


### PR DESCRIPTION
## Summary
- add anchored navigation to About, Skills, Experience, and Contact
- showcase skills and internships in new sections
- provide contact info for quick reachout

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f942775d08327a6d594be28cd95da