### PR TITLE
Add project mockup images

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -80,8 +80,8 @@ export default function Page() {
       Mockup: EcommerceMockup,
     },
     {
-      title: "SaaS Dashboard",
-      desc: "Interactive charts, authentication, and responsive layout.",
+      title: "Cleaning Service Dashboard",
+      desc: "Client statistics and booking system for a cleaning company.",
       href: "/projects/saas-dashboard",
       Mockup: SaasMockup,
     },

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,11 @@ import { motion } from "framer-motion";
 import Image from "next/image";
 import Link from "next/link";
 import CircuitBackground from "@/components/CircuitBackground";
+import {
+  PortfolioMockup,
+  EcommerceMockup,
+  SaasMockup,
+} from "@/components/ProjectMockups";
 
 const LINKS = {
   linkedin: "https://www.linkedin.com/in/erik-pérez",
@@ -66,16 +71,19 @@ export default function Page() {
       title: "Portfolio Website",
       desc: "Responsive Next.js site showcasing developer profile.",
       href: "/projects/portfolio-website",
+      Mockup: PortfolioMockup,
     },
     {
       title: "E‑commerce Storefront",
       desc: "Product listings, cart interactions, and checkout flow.",
       href: "/projects/ecommerce-storefront",
+      Mockup: EcommerceMockup,
     },
     {
       title: "SaaS Dashboard",
       desc: "Interactive charts, authentication, and responsive layout.",
       href: "/projects/saas-dashboard",
+      Mockup: SaasMockup,
     },
   ] as const;
 
@@ -292,7 +300,9 @@ export default function Page() {
               <FadeIn key={p.title} delay={0.03 * i}>
                 <Link href={p.href} className="block">
                   <Card className="overflow-hidden">
-                    <div className="aspect-video bg-neutral-900" />
+                    <div className="aspect-video">
+                      <p.Mockup className="w-full h-full object-cover" />
+                    </div>
                     <div className="p-4">
                       <h3 className="font-medium">{p.title}</h3>
                       <p className="mt-1 text-sm text-neutral-400">{p.desc}</p>

--- a/app/projects/ecommerce-storefront/page.tsx
+++ b/app/projects/ecommerce-storefront/page.tsx
@@ -20,6 +20,14 @@ export default function Page() {
         <div className="mt-8 mx-auto max-w-4xl aspect-video">
           <EcommerceMockup className="w-full h-full rounded-xl" />
         </div>
+        <div className="mt-8">
+          <Link
+            href="/projects/ecommerce-storefront/store"
+            className="inline-block bg-indigo-500 hover:bg-indigo-400 px-6 py-2 rounded-xl text-sm font-medium"
+          >
+            Launch Demo Store
+          </Link>
+        </div>
       </section>
       <section className="bg-neutral-800 py-16 px-4">
         <div className="max-w-4xl mx-auto grid md:grid-cols-3 gap-8">

--- a/app/projects/ecommerce-storefront/page.tsx
+++ b/app/projects/ecommerce-storefront/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { EcommerceMockup } from "@/components/ProjectMockups";
 
 export default function Page() {
   return (
@@ -16,6 +17,9 @@ export default function Page() {
         <p className="mt-4 text-neutral-300">
           Product listings, cart interactions, and smooth checkout flow.
         </p>
+        <div className="mt-8 mx-auto max-w-4xl aspect-video">
+          <EcommerceMockup className="w-full h-full rounded-xl" />
+        </div>
       </section>
       <section className="bg-neutral-800 py-16 px-4">
         <div className="max-w-4xl mx-auto grid md:grid-cols-3 gap-8">

--- a/app/projects/ecommerce-storefront/store/page.tsx
+++ b/app/projects/ecommerce-storefront/store/page.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+
+interface Product {
+  id: number;
+  name: string;
+  price: number;
+  color: string;
+}
+
+const PRODUCTS: Product[] = [
+  { id: 1, name: 'T‑Shirt', price: 25, color: 'bg-pink-500' },
+  { id: 2, name: 'Sneakers', price: 80, color: 'bg-green-500' },
+  { id: 3, name: 'Backpack', price: 50, color: 'bg-blue-500' },
+];
+
+export default function StorePage() {
+  const [cart, setCart] = useState<Record<number, number>>({});
+
+  const addToCart = (id: number) => {
+    setCart((c) => ({ ...c, [id]: (c[id] || 0) + 1 }));
+  };
+
+  const removeFromCart = (id: number) => {
+    setCart((c) => {
+      const qty = (c[id] || 0) - 1;
+      const copy = { ...c };
+      if (qty > 0) copy[id] = qty;
+      else delete copy[id];
+      return copy;
+    });
+  };
+
+  const total = PRODUCTS.reduce(
+    (sum, p) => sum + (cart[p.id] || 0) * p.price,
+    0
+  );
+
+  return (
+    <main className="min-h-screen bg-neutral-900 text-white">
+      <header className="border-b border-white/5">
+        <div className="max-w-6xl mx-auto px-4 py-6 flex justify-between items-center">
+          <h1 className="font-bold text-xl">Demo Store</h1>
+          <Link href="/projects/ecommerce-storefront" className="text-sm text-indigo-400 hover:underline">
+            ← Back to project
+          </Link>
+        </div>
+      </header>
+
+      <section className="max-w-6xl mx-auto p-4">
+        <h2 className="text-2xl font-semibold mb-6">Products</h2>
+        <div className="grid md:grid-cols-3 gap-6">
+          {PRODUCTS.map((p) => (
+            <div
+              key={p.id}
+              className="border border-white/5 rounded-xl p-4 flex flex-col"
+            >
+              <div className={`h-32 ${p.color} rounded-lg mb-4`} />
+              <h3 className="font-medium">{p.name}</h3>
+              <p className="text-sm text-neutral-300 mb-4">${p.price}</p>
+              <button
+                onClick={() => addToCart(p.id)}
+                className="mt-auto bg-indigo-500 hover:bg-indigo-400 px-4 py-2 text-sm rounded-lg"
+              >
+                Add to Cart
+              </button>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="bg-neutral-800 py-10 px-4 mt-10">
+        <div className="max-w-6xl mx-auto">
+          <h2 className="text-2xl font-semibold mb-4">Cart</h2>
+          {Object.keys(cart).length === 0 ? (
+            <p className="text-neutral-400 text-sm">Your cart is empty.</p>
+          ) : (
+            <ul className="space-y-2">
+              {PRODUCTS.filter((p) => cart[p.id]).map((p) => (
+                <li key={p.id} className="flex items-center justify-between text-sm">
+                  <span>
+                    {p.name} × {cart[p.id]}
+                  </span>
+                  <div className="flex items-center gap-3">
+                    <span>${(cart[p.id] * p.price).toFixed(2)}</span>
+                    <button
+                      onClick={() => removeFromCart(p.id)}
+                      className="text-red-400 hover:text-red-300 text-xs"
+                    >
+                      Remove
+                    </button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+          <div className="mt-4 font-medium">
+            Total: ${total.toFixed(2)}
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}
+

--- a/app/projects/portfolio-website/page.tsx
+++ b/app/projects/portfolio-website/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { PortfolioMockup } from "@/components/ProjectMockups";
 
 export default function Page() {
   return (
@@ -16,6 +17,9 @@ export default function Page() {
         <p className="mt-4 text-neutral-300">
           Showcase skills and projects with a clean, responsive design.
         </p>
+        <div className="mt-8 mx-auto max-w-4xl aspect-video">
+          <PortfolioMockup className="w-full h-full rounded-xl" />
+        </div>
       </section>
       <section className="bg-neutral-800 py-16 px-4">
         <div className="max-w-4xl mx-auto grid md:grid-cols-3 gap-8">

--- a/app/projects/saas-dashboard/dashboard/page.tsx
+++ b/app/projects/saas-dashboard/dashboard/page.tsx
@@ -3,17 +3,29 @@
 import { useState } from 'react';
 import Link from 'next/link';
 
-const DATA = {
-  visitors: [120, 90, 150, 170, 130, 160, 180],
-  revenue: [80, 100, 90, 120, 95, 130, 110],
+const STATS = {
+  clients: [5, 7, 6, 8, 9, 11, 10],
+  jobs: [3, 4, 5, 6, 5, 7, 8],
 };
 
 export default function DashboardDemo() {
-  const [metric, setMetric] = useState<'visitors' | 'revenue'>('visitors');
-  const data = DATA[metric];
+  const [metric, setMetric] = useState<'clients' | 'jobs'>('clients');
+  const data = STATS[metric];
+  const [bookings, setBookings] = useState<{ name: string; date: string }[]>([]);
   const height = 200;
   const barWidth = 40;
   const gap = 20;
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const formData = new FormData(e.currentTarget);
+    const name = formData.get('name') as string;
+    const date = formData.get('date') as string;
+    if (name && date) {
+      setBookings([...bookings, { name, date }]);
+      e.currentTarget.reset();
+    }
+  }
 
   return (
     <main className="min-h-screen bg-neutral-900 text-white">
@@ -29,20 +41,20 @@ export default function DashboardDemo() {
       <section className="max-w-6xl mx-auto p-4">
         <div className="flex gap-4 mb-6">
           <button
-            onClick={() => setMetric('visitors')}
+            onClick={() => setMetric('clients')}
             className={`px-4 py-2 text-sm rounded-lg border border-white/5 ${
-              metric === 'visitors' ? 'bg-indigo-500' : 'bg-neutral-800 hover:bg-neutral-700'
+              metric === 'clients' ? 'bg-indigo-500' : 'bg-neutral-800 hover:bg-neutral-700'
             }`}
           >
-            Visitors
+            Clients
           </button>
           <button
-            onClick={() => setMetric('revenue')}
+            onClick={() => setMetric('jobs')}
             className={`px-4 py-2 text-sm rounded-lg border border-white/5 ${
-              metric === 'revenue' ? 'bg-indigo-500' : 'bg-neutral-800 hover:bg-neutral-700'
+              metric === 'jobs' ? 'bg-indigo-500' : 'bg-neutral-800 hover:bg-neutral-700'
             }`}
           >
-            Revenue
+            Jobs
           </button>
         </div>
 
@@ -54,28 +66,69 @@ export default function DashboardDemo() {
             <rect
               key={i}
               x={gap + i * (barWidth + gap)}
-              y={height - v}
+              y={height - v * 10}
               width={barWidth}
-              height={v}
+              height={v * 10}
               className="fill-indigo-400"
             />
           ))}
         </svg>
       </section>
 
+      <section className="max-w-6xl mx-auto p-4 mt-10">
+        <h2 className="text-lg font-semibold mb-4">Book a Cleaning</h2>
+        <form onSubmit={handleSubmit} className="flex flex-col sm:flex-row gap-2">
+          <input
+            name="name"
+            placeholder="Client name"
+            className="flex-1 px-3 py-2 rounded-lg bg-neutral-800 border border-white/5"
+            required
+          />
+          <input
+            type="date"
+            name="date"
+            className="px-3 py-2 rounded-lg bg-neutral-800 border border-white/5 flex-1 sm:flex-none"
+            required
+          />
+          <button
+            type="submit"
+            className="px-4 py-2 rounded-lg bg-indigo-500 text-sm hover:bg-indigo-400"
+          >
+            Add
+          </button>
+        </form>
+        <ul className="mt-4 space-y-1 text-sm">
+          {bookings.map((b, i) => (
+            <li
+              key={i}
+              className="flex justify-between bg-neutral-800 rounded-lg px-3 py-2"
+            >
+              <span>{b.name}</span>
+              <span>{b.date}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+
       <section className="bg-neutral-800 py-10 px-4 mt-10">
         <div className="max-w-6xl mx-auto grid md:grid-cols-3 gap-8">
           <div className="space-y-2">
-            <h3 className="font-semibold text-lg">Users</h3>
-            <p className="text-neutral-400 text-sm">Monitor daily active users.</p>
+            <h3 className="font-semibold text-lg">Clients</h3>
+            <p className="text-neutral-400 text-sm">
+              Monitor growth of your client base.
+            </p>
           </div>
           <div className="space-y-2">
-            <h3 className="font-semibold text-lg">Revenue</h3>
-            <p className="text-neutral-400 text-sm">Track subscription income.</p>
+            <h3 className="font-semibold text-lg">Bookings</h3>
+            <p className="text-neutral-400 text-sm">
+              Track scheduled cleanings at a glance.
+            </p>
           </div>
           <div className="space-y-2">
             <h3 className="font-semibold text-lg">Performance</h3>
-            <p className="text-neutral-400 text-sm">Keep latency low worldwide.</p>
+            <p className="text-neutral-400 text-sm">
+              Keep teams efficient and on time.
+            </p>
           </div>
         </div>
       </section>

--- a/app/projects/saas-dashboard/dashboard/page.tsx
+++ b/app/projects/saas-dashboard/dashboard/page.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+
+const DATA = {
+  visitors: [120, 90, 150, 170, 130, 160, 180],
+  revenue: [80, 100, 90, 120, 95, 130, 110],
+};
+
+export default function DashboardDemo() {
+  const [metric, setMetric] = useState<'visitors' | 'revenue'>('visitors');
+  const data = DATA[metric];
+  const height = 200;
+  const barWidth = 40;
+  const gap = 20;
+
+  return (
+    <main className="min-h-screen bg-neutral-900 text-white">
+      <header className="border-b border-white/5">
+        <div className="max-w-6xl mx-auto px-4 py-6 flex justify-between items-center">
+          <h1 className="font-bold text-xl">Dashboard Demo</h1>
+          <Link href="/projects/saas-dashboard" className="text-sm text-indigo-400 hover:underline">
+            ← Back to project
+          </Link>
+        </div>
+      </header>
+
+      <section className="max-w-6xl mx-auto p-4">
+        <div className="flex gap-4 mb-6">
+          <button
+            onClick={() => setMetric('visitors')}
+            className={`px-4 py-2 text-sm rounded-lg border border-white/5 ${
+              metric === 'visitors' ? 'bg-indigo-500' : 'bg-neutral-800 hover:bg-neutral-700'
+            }`}
+          >
+            Visitors
+          </button>
+          <button
+            onClick={() => setMetric('revenue')}
+            className={`px-4 py-2 text-sm rounded-lg border border-white/5 ${
+              metric === 'revenue' ? 'bg-indigo-500' : 'bg-neutral-800 hover:bg-neutral-700'
+            }`}
+          >
+            Revenue
+          </button>
+        </div>
+
+        <svg
+          viewBox={`0 0 ${data.length * (barWidth + gap) + gap} ${height}`}
+          className="w-full h-48 bg-neutral-800 rounded-xl"
+        >
+          {data.map((v, i) => (
+            <rect
+              key={i}
+              x={gap + i * (barWidth + gap)}
+              y={height - v}
+              width={barWidth}
+              height={v}
+              className="fill-indigo-400"
+            />
+          ))}
+        </svg>
+      </section>
+
+      <section className="bg-neutral-800 py-10 px-4 mt-10">
+        <div className="max-w-6xl mx-auto grid md:grid-cols-3 gap-8">
+          <div className="space-y-2">
+            <h3 className="font-semibold text-lg">Users</h3>
+            <p className="text-neutral-400 text-sm">Monitor daily active users.</p>
+          </div>
+          <div className="space-y-2">
+            <h3 className="font-semibold text-lg">Revenue</h3>
+            <p className="text-neutral-400 text-sm">Track subscription income.</p>
+          </div>
+          <div className="space-y-2">
+            <h3 className="font-semibold text-lg">Performance</h3>
+            <p className="text-neutral-400 text-sm">Keep latency low worldwide.</p>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}
+

--- a/app/projects/saas-dashboard/page.tsx
+++ b/app/projects/saas-dashboard/page.tsx
@@ -20,6 +20,14 @@ export default function Page() {
         <div className="mt-8 mx-auto max-w-4xl aspect-video">
           <SaasMockup className="w-full h-full rounded-xl" />
         </div>
+        <div className="mt-8">
+          <Link
+            href="/projects/saas-dashboard/dashboard"
+            className="inline-block bg-indigo-500 hover:bg-indigo-400 px-6 py-2 rounded-xl text-sm font-medium"
+          >
+            Launch Demo Dashboard
+          </Link>
+        </div>
       </section>
       <section className="bg-neutral-800 py-16 px-4">
         <div className="max-w-4xl mx-auto grid md:grid-cols-3 gap-8">

--- a/app/projects/saas-dashboard/page.tsx
+++ b/app/projects/saas-dashboard/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { SaasMockup } from "@/components/ProjectMockups";
 
 export default function Page() {
   return (
@@ -16,6 +17,9 @@ export default function Page() {
         <p className="mt-4 text-neutral-300">
           Interactive charts, user authentication, and responsive layout.
         </p>
+        <div className="mt-8 mx-auto max-w-4xl aspect-video">
+          <SaasMockup className="w-full h-full rounded-xl" />
+        </div>
       </section>
       <section className="bg-neutral-800 py-16 px-4">
         <div className="max-w-4xl mx-auto grid md:grid-cols-3 gap-8">

--- a/app/projects/saas-dashboard/page.tsx
+++ b/app/projects/saas-dashboard/page.tsx
@@ -6,16 +6,16 @@ export default function Page() {
     <main className="min-h-screen bg-neutral-900 text-white">
       <header className="border-b border-white/5">
         <div className="max-w-6xl mx-auto px-4 py-6 flex justify-between items-center">
-          <h1 className="font-bold text-xl">SaaS Dashboard</h1>
+          <h1 className="font-bold text-xl">Cleaning Service Dashboard</h1>
           <Link href="/" className="text-sm text-indigo-400 hover:underline">
             ← Back home
           </Link>
         </div>
       </header>
       <section className="text-center py-20 px-4">
-        <h2 className="text-4xl font-bold">Insightful Analytics</h2>
+        <h2 className="text-4xl font-bold">Manage Your Cleaning Business</h2>
         <p className="mt-4 text-neutral-300">
-          Interactive charts, user authentication, and responsive layout.
+          Track client statistics and handle bookings in one place.
         </p>
         <div className="mt-8 mx-auto max-w-4xl aspect-video">
           <SaasMockup className="w-full h-full rounded-xl" />
@@ -32,15 +32,15 @@ export default function Page() {
       <section className="bg-neutral-800 py-16 px-4">
         <div className="max-w-4xl mx-auto grid md:grid-cols-3 gap-8">
           <div className="space-y-2">
-            <h3 className="font-semibold text-lg">Charts</h3>
+            <h3 className="font-semibold text-lg">Client Stats</h3>
             <p className="text-neutral-400 text-sm">
-              Visualize data with dynamic and interactive graphs.
+              Visualize active clients and completed jobs.
             </p>
           </div>
           <div className="space-y-2">
-            <h3 className="font-semibold text-lg">Accounts</h3>
+            <h3 className="font-semibold text-lg">Bookings</h3>
             <p className="text-neutral-400 text-sm">
-              Secure authentication and role‑based access.
+              Accept and manage cleaning appointments.
             </p>
           </div>
           <div className="space-y-2">

--- a/components/ProjectMockups.tsx
+++ b/components/ProjectMockups.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+
+interface MockupProps {
+  className?: string;
+}
+
+export function PortfolioMockup({ className = "" }: MockupProps) {
+  return (
+    <svg
+      viewBox="0 0 400 250"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+    >
+      <rect width="400" height="250" rx="16" fill="#1f2937" />
+      <rect x="20" y="20" width="360" height="40" rx="8" fill="#374151" />
+      <rect x="20" y="80" width="170" height="150" rx="8" fill="#4b5563" />
+      <rect x="200" y="80" width="180" height="70" rx="8" fill="#4b5563" />
+      <rect x="200" y="160" width="180" height="70" rx="8" fill="#4b5563" />
+    </svg>
+  );
+}
+
+export function EcommerceMockup({ className = "" }: MockupProps) {
+  return (
+    <svg
+      viewBox="0 0 400 250"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+    >
+      <rect width="400" height="250" rx="16" fill="#1f2937" />
+      <rect x="20" y="20" width="360" height="40" rx="8" fill="#374151" />
+      <rect x="20" y="80" width="110" height="150" rx="8" fill="#4b5563" />
+      <rect x="140" y="80" width="110" height="150" rx="8" fill="#4b5563" />
+      <rect x="260" y="80" width="110" height="150" rx="8" fill="#4b5563" />
+    </svg>
+  );
+}
+
+export function SaasMockup({ className = "" }: MockupProps) {
+  return (
+    <svg
+      viewBox="0 0 400 250"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+    >
+      <rect width="400" height="250" rx="16" fill="#1f2937" />
+      <rect x="20" y="20" width="360" height="40" rx="8" fill="#374151" />
+      <rect x="20" y="80" width="160" height="100" rx="8" fill="#4b5563" />
+      <rect x="200" y="80" width="180" height="50" rx="8" fill="#4b5563" />
+      <rect x="200" y="140" width="180" height="90" rx="8" fill="#4b5563" />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary
- replace PNG mockup assets with SVG components
- render SVG mockups on home page project cards
- display code-generated mockups on individual project pages

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: prompts for ESLint setup)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c46b4a40048327a1cf026a45ec543a