### PR TITLE
Revamp CoreVision branding with circuit-inspired logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <br />
 <div align="center">
   <a href="https://github.com/xerikperez/my-portfolio">
-    <img src="logo.png" alt="Logo" width="80" height="80">
+    <img src="logo.svg" alt="CoreVision logo" width="80" height="80">
   </a>
 
 <h3 align="center">Portfolio Website</h3>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
   title: "CoreVisionEP – HomePage",
   description:
     "Welcome to CoreVisionEP, where we build fast, elegant, and automated web solutions.",
-  icons: "/logo.png",
+  icons: "/logo.svg",
 };
 
 // (Optional Local Font) — if you own a licensed Tesla‑style font file

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,9 +2,9 @@
 
 import { useState } from "react";
 import { motion } from "framer-motion";
-import Image from "next/image";
 import Link from "next/link";
 import CircuitBackground from "@/components/CircuitBackground";
+import Logo from "@/components/Logo";
 import {
   PortfolioMockup,
   EcommerceMockup,
@@ -94,13 +94,12 @@ export default function Page() {
       <header className="fixed top-0 inset-x-0 z-40">
         <div className="mx-auto max-w-6xl px-4">
           <nav className="mt-4 flex items-center justify-between rounded-2xl glass px-4 py-2">
-            <a href="#home" className="flex items-center">
-              <Image
-                src="/logo.png"
-                alt="CoreVision logo"
-                width={32}
-                height={32}
-                priority
+            <a href="#home" className="flex items-center" aria-label="CoreVision home">
+              <Logo
+                className="select-none"
+                glyphClassName="h-9 w-9 sm:h-10 sm:w-10"
+                wordmarkClassName="hidden sm:block"
+                withWordmark
               />
             </a>
             <div className="hidden md:flex items-center gap-2">

--- a/components/Logo.tsx
+++ b/components/Logo.tsx
@@ -1,0 +1,177 @@
+import * as React from "react";
+
+interface LogoProps {
+  className?: string;
+  glyphClassName?: string;
+  wordmarkClassName?: string;
+  withWordmark?: boolean;
+}
+
+const LogoGlyph: React.FC<React.SVGProps<SVGSVGElement>> = ({ className, ...props }) => (
+  <svg
+    viewBox="0 0 64 64"
+    role="img"
+    aria-hidden
+    focusable="false"
+    className={className}
+    {...props}
+  >
+    <rect width="64" height="64" rx="18" fill="url(#logo-paint0_linear)" />
+    <rect
+      x="1.5"
+      y="1.5"
+      width="61"
+      height="61"
+      rx="16.5"
+      stroke="url(#logo-paint1_linear)"
+      strokeWidth="3"
+      opacity="0.45"
+    />
+    <path
+      d="M44 20C35.1634 20 28 27.1634 28 36C28 44.8366 35.1634 52 44 52"
+      stroke="url(#logo-paint2_linear)"
+      strokeWidth="4"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M18 24L26 44L34 32L40 44"
+      stroke="url(#logo-paint3_linear)"
+      strokeWidth="4"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M18 14H28"
+      stroke="url(#logo-paint4_linear)"
+      strokeWidth="2"
+      strokeLinecap="round"
+      opacity="0.6"
+    />
+    <path
+      d="M12 30H18"
+      stroke="url(#logo-paint5_linear)"
+      strokeWidth="2"
+      strokeLinecap="round"
+      opacity="0.55"
+    />
+    <path
+      d="M36 52H48"
+      stroke="url(#logo-paint6_linear)"
+      strokeWidth="2"
+      strokeLinecap="round"
+      opacity="0.5"
+    />
+    <circle cx="18" cy="14" r="2.2" fill="#22D3EE" />
+    <circle cx="28" cy="14" r="1.8" fill="#F472B6" />
+    <circle cx="12" cy="30" r="1.8" fill="#22D3EE" />
+    <circle cx="48" cy="52" r="2.2" fill="#F472B6" />
+    <defs>
+      <linearGradient
+        id="logo-paint0_linear"
+        x1="14"
+        y1="8"
+        x2="54"
+        y2="56"
+        gradientUnits="userSpaceOnUse"
+      >
+        <stop offset="0" stopColor="#312E81" />
+        <stop offset="0.48" stopColor="#111827" />
+        <stop offset="1" stopColor="#0B1120" />
+      </linearGradient>
+      <linearGradient
+        id="logo-paint1_linear"
+        x1="12"
+        y1="8"
+        x2="52"
+        y2="56"
+        gradientUnits="userSpaceOnUse"
+      >
+        <stop stopColor="#6366F1" stopOpacity="0.85" />
+        <stop offset="0.5" stopColor="#8B5CF6" stopOpacity="0.45" />
+        <stop offset="1" stopColor="#EC4899" stopOpacity="0.85" />
+      </linearGradient>
+      <linearGradient
+        id="logo-paint2_linear"
+        x1="26"
+        y1="24"
+        x2="50"
+        y2="52"
+        gradientUnits="userSpaceOnUse"
+      >
+        <stop stopColor="#22D3EE" />
+        <stop offset="1" stopColor="#818CF8" />
+      </linearGradient>
+      <linearGradient
+        id="logo-paint3_linear"
+        x1="18"
+        y1="24"
+        x2="42"
+        y2="46"
+        gradientUnits="userSpaceOnUse"
+      >
+        <stop stopColor="#C084FC" />
+        <stop offset="1" stopColor="#EC4899" />
+      </linearGradient>
+      <linearGradient
+        id="logo-paint4_linear"
+        x1="18"
+        y1="14"
+        x2="28"
+        y2="14"
+        gradientUnits="userSpaceOnUse"
+      >
+        <stop stopColor="#22D3EE" />
+        <stop offset="1" stopColor="#38BDF8" />
+      </linearGradient>
+      <linearGradient
+        id="logo-paint5_linear"
+        x1="12"
+        y1="30"
+        x2="18"
+        y2="30"
+        gradientUnits="userSpaceOnUse"
+      >
+        <stop stopColor="#A855F7" />
+        <stop offset="1" stopColor="#EC4899" />
+      </linearGradient>
+      <linearGradient
+        id="logo-paint6_linear"
+        x1="36"
+        y1="52"
+        x2="48"
+        y2="52"
+        gradientUnits="userSpaceOnUse"
+      >
+        <stop stopColor="#22D3EE" />
+        <stop offset="1" stopColor="#F472B6" />
+      </linearGradient>
+    </defs>
+  </svg>
+);
+
+const Logo: React.FC<LogoProps> = ({
+  className = "",
+  glyphClassName = "h-10 w-10",
+  wordmarkClassName = "",
+  withWordmark = false,
+}) => {
+  return (
+    <span
+      className={`inline-flex items-center ${withWordmark ? "gap-3" : ""} text-white ${className}`.trim()}
+      aria-hidden={!withWordmark}
+    >
+      <LogoGlyph className={glyphClassName} />
+      {withWordmark && (
+        <span
+          className={`font-[var(--font-orbitron)] uppercase tracking-[0.45em] text-xs sm:text-sm text-white/90 ${wordmarkClassName}`.trim()}
+        >
+          CoreVision
+        </span>
+      )}
+    </span>
+  );
+};
+
+export default Logo;
+export { LogoGlyph };

--- a/components/Logo.tsx
+++ b/components/Logo.tsx
@@ -18,133 +18,149 @@ const LogoGlyph: React.FC<React.SVGProps<SVGSVGElement>> = ({ className, ...prop
   >
     <rect width="64" height="64" rx="18" fill="url(#logo-paint0_linear)" />
     <rect
-      x="1.5"
-      y="1.5"
-      width="61"
-      height="61"
-      rx="16.5"
-      stroke="url(#logo-paint1_linear)"
-      strokeWidth="3"
-      opacity="0.45"
-    />
-    <path
-      d="M44 20C35.1634 20 28 27.1634 28 36C28 44.8366 35.1634 52 44 52"
-      stroke="url(#logo-paint2_linear)"
-      strokeWidth="4"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-    <path
-      d="M18 24L26 44L34 32L40 44"
-      stroke="url(#logo-paint3_linear)"
-      strokeWidth="4"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-    <path
-      d="M18 14H28"
-      stroke="url(#logo-paint4_linear)"
+      x="2"
+      y="2"
+      width="60"
+      height="60"
+      rx="16"
+      stroke="url(#logo-paint1_radial)"
       strokeWidth="2"
-      strokeLinecap="round"
       opacity="0.6"
     />
-    <path
-      d="M12 30H18"
-      stroke="url(#logo-paint5_linear)"
-      strokeWidth="2"
-      strokeLinecap="round"
-      opacity="0.55"
-    />
-    <path
-      d="M36 52H48"
-      stroke="url(#logo-paint6_linear)"
-      strokeWidth="2"
-      strokeLinecap="round"
-      opacity="0.5"
-    />
-    <circle cx="18" cy="14" r="2.2" fill="#22D3EE" />
-    <circle cx="28" cy="14" r="1.8" fill="#F472B6" />
-    <circle cx="12" cy="30" r="1.8" fill="#22D3EE" />
-    <circle cx="48" cy="52" r="2.2" fill="#F472B6" />
+    <g filter="url(#logo-glow)">
+      <path
+        d="M42.5 20H33c-6.075 0-11 4.925-11 11v2c0 6.075 4.925 11 11 11h7"
+        stroke="url(#logo-paint2_linear)"
+        strokeWidth="4"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M24.5 20.5L32 44l6.8-13.5"
+        stroke="url(#logo-paint3_linear)"
+        strokeWidth="4"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </g>
+    <g opacity="0.7">
+      <path
+        d="M20 16h8"
+        stroke="url(#logo-paint4_linear)"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+      <path
+        d="M16 26h4"
+        stroke="url(#logo-paint5_linear)"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+      <path
+        d="M38 50h10"
+        stroke="url(#logo-paint6_linear)"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+    </g>
+    <circle cx="20" cy="16" r="2" fill="#7DF9FF" />
+    <circle cx="28" cy="16" r="1.8" fill="#A855F7" />
+    <circle cx="16" cy="26" r="1.6" fill="#38BDF8" />
+    <circle cx="48" cy="50" r="2" fill="#F472B6" />
+    <circle cx="34" cy="12" r="1.2" fill="#C084FC" opacity="0.75" />
+    <circle cx="46" cy="28" r="1.4" fill="#22D3EE" opacity="0.85" />
     <defs>
+      <filter
+        id="logo-glow"
+        x="11"
+        y="11"
+        width="42"
+        height="42"
+        filterUnits="userSpaceOnUse"
+        colorInterpolationFilters="sRGB"
+      >
+        <feGaussianBlur stdDeviation="1.75" result="blur" />
+        <feComposite in="SourceGraphic" in2="blur" operator="over" />
+      </filter>
       <linearGradient
         id="logo-paint0_linear"
-        x1="14"
-        y1="8"
-        x2="54"
-        y2="56"
-        gradientUnits="userSpaceOnUse"
-      >
-        <stop offset="0" stopColor="#312E81" />
-        <stop offset="0.48" stopColor="#111827" />
-        <stop offset="1" stopColor="#0B1120" />
-      </linearGradient>
-      <linearGradient
-        id="logo-paint1_linear"
-        x1="12"
+        x1="10"
         y1="8"
         x2="52"
         y2="56"
         gradientUnits="userSpaceOnUse"
       >
-        <stop stopColor="#6366F1" stopOpacity="0.85" />
-        <stop offset="0.5" stopColor="#8B5CF6" stopOpacity="0.45" />
-        <stop offset="1" stopColor="#EC4899" stopOpacity="0.85" />
+        <stop offset="0" stopColor="#1B1C3A" />
+        <stop offset="0.4" stopColor="#101226" />
+        <stop offset="1" stopColor="#050611" />
       </linearGradient>
+      <radialGradient
+        id="logo-paint1_radial"
+        cx="0"
+        cy="0"
+        r="1"
+        gradientUnits="userSpaceOnUse"
+        gradientTransform="translate(32 32) scale(30)"
+      >
+        <stop offset="0.2" stopColor="#60A5FA" stopOpacity="0.75" />
+        <stop offset="0.55" stopColor="#8B5CF6" stopOpacity="0.4" />
+        <stop offset="1" stopColor="#EC4899" stopOpacity="0.75" />
+      </radialGradient>
       <linearGradient
         id="logo-paint2_linear"
-        x1="26"
-        y1="24"
-        x2="50"
-        y2="52"
+        x1="22"
+        y1="22"
+        x2="43"
+        y2="44"
         gradientUnits="userSpaceOnUse"
       >
-        <stop stopColor="#22D3EE" />
-        <stop offset="1" stopColor="#818CF8" />
+        <stop stopColor="#67E8F9" />
+        <stop offset="0.55" stopColor="#38BDF8" />
+        <stop offset="1" stopColor="#6366F1" />
       </linearGradient>
       <linearGradient
         id="logo-paint3_linear"
-        x1="18"
-        y1="24"
-        x2="42"
-        y2="46"
+        x1="24"
+        y1="21"
+        x2="39"
+        y2="41"
         gradientUnits="userSpaceOnUse"
       >
         <stop stopColor="#C084FC" />
-        <stop offset="1" stopColor="#EC4899" />
+        <stop offset="1" stopColor="#FB7185" />
       </linearGradient>
       <linearGradient
         id="logo-paint4_linear"
-        x1="18"
-        y1="14"
+        x1="20"
+        y1="16"
         x2="28"
-        y2="14"
+        y2="16"
         gradientUnits="userSpaceOnUse"
       >
-        <stop stopColor="#22D3EE" />
+        <stop stopColor="#5EEAD4" />
         <stop offset="1" stopColor="#38BDF8" />
       </linearGradient>
       <linearGradient
         id="logo-paint5_linear"
-        x1="12"
-        y1="30"
-        x2="18"
-        y2="30"
+        x1="16"
+        y1="26"
+        x2="20"
+        y2="26"
         gradientUnits="userSpaceOnUse"
       >
-        <stop stopColor="#A855F7" />
+        <stop stopColor="#818CF8" />
         <stop offset="1" stopColor="#EC4899" />
       </linearGradient>
       <linearGradient
         id="logo-paint6_linear"
-        x1="36"
-        y1="52"
+        x1="38"
+        y1="50"
         x2="48"
-        y2="52"
+        y2="50"
         gradientUnits="userSpaceOnUse"
       >
         <stop stopColor="#22D3EE" />
-        <stop offset="1" stopColor="#F472B6" />
+        <stop offset="1" stopColor="#A855F7" />
       </linearGradient>
     </defs>
   </svg>
@@ -164,7 +180,9 @@ const Logo: React.FC<LogoProps> = ({
       <LogoGlyph className={glyphClassName} />
       {withWordmark && (
         <span
-          className={`font-[var(--font-orbitron)] uppercase tracking-[0.45em] text-xs sm:text-sm text-white/90 ${wordmarkClassName}`.trim()}
+          className={
+            `font-[var(--font-orbitron)] uppercase tracking-[0.45em] text-xs sm:text-sm bg-gradient-to-r from-sky-300 via-indigo-300 to-pink-300 text-transparent bg-clip-text ${wordmarkClassName}`.trim()
+          }
         >
           CoreVision
         </span>

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,134 @@
+<svg width="256" height="256" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <title>CoreVision monogram</title>
+  <rect width="64" height="64" rx="18" fill="url(#logo-paint0_linear)" />
+  <rect
+    x="1.5"
+    y="1.5"
+    width="61"
+    height="61"
+    rx="16.5"
+    stroke="url(#logo-paint1_linear)"
+    stroke-width="3"
+    opacity="0.45"
+  />
+  <path
+    d="M44 20C35.1634 20 28 27.1634 28 36C28 44.8366 35.1634 52 44 52"
+    stroke="url(#logo-paint2_linear)"
+    stroke-width="4"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+  <path
+    d="M18 24L26 44L34 32L40 44"
+    stroke="url(#logo-paint3_linear)"
+    stroke-width="4"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+  <path
+    d="M18 14H28"
+    stroke="url(#logo-paint4_linear)"
+    stroke-width="2"
+    stroke-linecap="round"
+    opacity="0.6"
+  />
+  <path
+    d="M12 30H18"
+    stroke="url(#logo-paint5_linear)"
+    stroke-width="2"
+    stroke-linecap="round"
+    opacity="0.55"
+  />
+  <path
+    d="M36 52H48"
+    stroke="url(#logo-paint6_linear)"
+    stroke-width="2"
+    stroke-linecap="round"
+    opacity="0.5"
+  />
+  <circle cx="18" cy="14" r="2.2" fill="#22D3EE" />
+  <circle cx="28" cy="14" r="1.8" fill="#F472B6" />
+  <circle cx="12" cy="30" r="1.8" fill="#22D3EE" />
+  <circle cx="48" cy="52" r="2.2" fill="#F472B6" />
+  <defs>
+    <linearGradient
+      id="logo-paint0_linear"
+      x1="14"
+      y1="8"
+      x2="54"
+      y2="56"
+      gradientUnits="userSpaceOnUse"
+    >
+      <stop offset="0" stop-color="#312E81" />
+      <stop offset="0.48" stop-color="#111827" />
+      <stop offset="1" stop-color="#0B1120" />
+    </linearGradient>
+    <linearGradient
+      id="logo-paint1_linear"
+      x1="12"
+      y1="8"
+      x2="52"
+      y2="56"
+      gradientUnits="userSpaceOnUse"
+    >
+      <stop stop-color="#6366F1" stop-opacity="0.85" />
+      <stop offset="0.5" stop-color="#8B5CF6" stop-opacity="0.45" />
+      <stop offset="1" stop-color="#EC4899" stop-opacity="0.85" />
+    </linearGradient>
+    <linearGradient
+      id="logo-paint2_linear"
+      x1="26"
+      y1="24"
+      x2="50"
+      y2="52"
+      gradientUnits="userSpaceOnUse"
+    >
+      <stop stop-color="#22D3EE" />
+      <stop offset="1" stop-color="#818CF8" />
+    </linearGradient>
+    <linearGradient
+      id="logo-paint3_linear"
+      x1="18"
+      y1="24"
+      x2="42"
+      y2="46"
+      gradientUnits="userSpaceOnUse"
+    >
+      <stop stop-color="#C084FC" />
+      <stop offset="1" stop-color="#EC4899" />
+    </linearGradient>
+    <linearGradient
+      id="logo-paint4_linear"
+      x1="18"
+      y1="14"
+      x2="28"
+      y2="14"
+      gradientUnits="userSpaceOnUse"
+    >
+      <stop stop-color="#22D3EE" />
+      <stop offset="1" stop-color="#38BDF8" />
+    </linearGradient>
+    <linearGradient
+      id="logo-paint5_linear"
+      x1="12"
+      y1="30"
+      x2="18"
+      y2="30"
+      gradientUnits="userSpaceOnUse"
+    >
+      <stop stop-color="#A855F7" />
+      <stop offset="1" stop-color="#EC4899" />
+    </linearGradient>
+    <linearGradient
+      id="logo-paint6_linear"
+      x1="36"
+      y1="52"
+      x2="48"
+      y2="52"
+      gradientUnits="userSpaceOnUse"
+    >
+      <stop stop-color="#22D3EE" />
+      <stop offset="1" stop-color="#F472B6" />
+    </linearGradient>
+  </defs>
+</svg>

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,134 +1,56 @@
 <svg width="256" height="256" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <title>CoreVision monogram</title>
   <rect width="64" height="64" rx="18" fill="url(#logo-paint0_linear)" />
-  <rect
-    x="1.5"
-    y="1.5"
-    width="61"
-    height="61"
-    rx="16.5"
-    stroke="url(#logo-paint1_linear)"
-    stroke-width="3"
-    opacity="0.45"
-  />
-  <path
-    d="M44 20C35.1634 20 28 27.1634 28 36C28 44.8366 35.1634 52 44 52"
-    stroke="url(#logo-paint2_linear)"
-    stroke-width="4"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-  />
-  <path
-    d="M18 24L26 44L34 32L40 44"
-    stroke="url(#logo-paint3_linear)"
-    stroke-width="4"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-  />
-  <path
-    d="M18 14H28"
-    stroke="url(#logo-paint4_linear)"
-    stroke-width="2"
-    stroke-linecap="round"
-    opacity="0.6"
-  />
-  <path
-    d="M12 30H18"
-    stroke="url(#logo-paint5_linear)"
-    stroke-width="2"
-    stroke-linecap="round"
-    opacity="0.55"
-  />
-  <path
-    d="M36 52H48"
-    stroke="url(#logo-paint6_linear)"
-    stroke-width="2"
-    stroke-linecap="round"
-    opacity="0.5"
-  />
-  <circle cx="18" cy="14" r="2.2" fill="#22D3EE" />
-  <circle cx="28" cy="14" r="1.8" fill="#F472B6" />
-  <circle cx="12" cy="30" r="1.8" fill="#22D3EE" />
-  <circle cx="48" cy="52" r="2.2" fill="#F472B6" />
+  <rect x="2" y="2" width="60" height="60" rx="16" stroke="url(#logo-paint1_radial)" stroke-width="2" opacity="0.6" />
+  <g filter="url(#logo-glow)">
+    <path d="M42.5 20H33C26.925 20 22 24.925 22 31V33C22 39.075 26.925 44 33 44H40" stroke="url(#logo-paint2_linear)" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M24.5 20.5L32 44L38.8 30.5" stroke="url(#logo-paint3_linear)" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" />
+  </g>
+  <g opacity="0.7">
+    <path d="M20 16H28" stroke="url(#logo-paint4_linear)" stroke-width="2" stroke-linecap="round" />
+    <path d="M16 26H20" stroke="url(#logo-paint5_linear)" stroke-width="2" stroke-linecap="round" />
+    <path d="M38 50H48" stroke="url(#logo-paint6_linear)" stroke-width="2" stroke-linecap="round" />
+  </g>
+  <circle cx="20" cy="16" r="2" fill="#7DF9FF" />
+  <circle cx="28" cy="16" r="1.8" fill="#A855F7" />
+  <circle cx="16" cy="26" r="1.6" fill="#38BDF8" />
+  <circle cx="48" cy="50" r="2" fill="#F472B6" />
+  <circle cx="34" cy="12" r="1.2" fill="#C084FC" opacity="0.75" />
+  <circle cx="46" cy="28" r="1.4" fill="#22D3EE" opacity="0.85" />
   <defs>
-    <linearGradient
-      id="logo-paint0_linear"
-      x1="14"
-      y1="8"
-      x2="54"
-      y2="56"
-      gradientUnits="userSpaceOnUse"
-    >
-      <stop offset="0" stop-color="#312E81" />
-      <stop offset="0.48" stop-color="#111827" />
-      <stop offset="1" stop-color="#0B1120" />
+    <filter id="logo-glow" x="11" y="11" width="42" height="42" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="1.75" result="blur" />
+      <feComposite in="SourceGraphic" in2="blur" operator="over" />
+    </filter>
+    <linearGradient id="logo-paint0_linear" x1="10" y1="8" x2="52" y2="56" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#1B1C3A" />
+      <stop offset="0.4" stop-color="#101226" />
+      <stop offset="1" stop-color="#050611" />
     </linearGradient>
-    <linearGradient
-      id="logo-paint1_linear"
-      x1="12"
-      y1="8"
-      x2="52"
-      y2="56"
-      gradientUnits="userSpaceOnUse"
-    >
-      <stop stop-color="#6366F1" stop-opacity="0.85" />
-      <stop offset="0.5" stop-color="#8B5CF6" stop-opacity="0.45" />
-      <stop offset="1" stop-color="#EC4899" stop-opacity="0.85" />
+    <radialGradient id="logo-paint1_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(32 32) scale(30)">
+      <stop offset="0.2" stop-color="#60A5FA" stop-opacity="0.75" />
+      <stop offset="0.55" stop-color="#8B5CF6" stop-opacity="0.4" />
+      <stop offset="1" stop-color="#EC4899" stop-opacity="0.75" />
+    </radialGradient>
+    <linearGradient id="logo-paint2_linear" x1="22" y1="22" x2="43" y2="44" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#67E8F9" />
+      <stop offset="0.55" stop-color="#38BDF8" />
+      <stop offset="1" stop-color="#6366F1" />
     </linearGradient>
-    <linearGradient
-      id="logo-paint2_linear"
-      x1="26"
-      y1="24"
-      x2="50"
-      y2="52"
-      gradientUnits="userSpaceOnUse"
-    >
-      <stop stop-color="#22D3EE" />
-      <stop offset="1" stop-color="#818CF8" />
-    </linearGradient>
-    <linearGradient
-      id="logo-paint3_linear"
-      x1="18"
-      y1="24"
-      x2="42"
-      y2="46"
-      gradientUnits="userSpaceOnUse"
-    >
+    <linearGradient id="logo-paint3_linear" x1="24" y1="21" x2="39" y2="41" gradientUnits="userSpaceOnUse">
       <stop stop-color="#C084FC" />
-      <stop offset="1" stop-color="#EC4899" />
+      <stop offset="1" stop-color="#FB7185" />
     </linearGradient>
-    <linearGradient
-      id="logo-paint4_linear"
-      x1="18"
-      y1="14"
-      x2="28"
-      y2="14"
-      gradientUnits="userSpaceOnUse"
-    >
-      <stop stop-color="#22D3EE" />
+    <linearGradient id="logo-paint4_linear" x1="20" y1="16" x2="28" y2="16" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#5EEAD4" />
       <stop offset="1" stop-color="#38BDF8" />
     </linearGradient>
-    <linearGradient
-      id="logo-paint5_linear"
-      x1="12"
-      y1="30"
-      x2="18"
-      y2="30"
-      gradientUnits="userSpaceOnUse"
-    >
-      <stop stop-color="#A855F7" />
+    <linearGradient id="logo-paint5_linear" x1="16" y1="26" x2="20" y2="26" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#818CF8" />
       <stop offset="1" stop-color="#EC4899" />
     </linearGradient>
-    <linearGradient
-      id="logo-paint6_linear"
-      x1="36"
-      y1="52"
-      x2="48"
-      y2="52"
-      gradientUnits="userSpaceOnUse"
-    >
+    <linearGradient id="logo-paint6_linear" x1="38" y1="50" x2="48" y2="50" gradientUnits="userSpaceOnUse">
       <stop stop-color="#22D3EE" />
-      <stop offset="1" stop-color="#F472B6" />
+      <stop offset="1" stop-color="#A855F7" />
     </linearGradient>
   </defs>
 </svg>


### PR DESCRIPTION
## Summary
- add a reusable Logo component that renders the new circuit-inspired CoreVision glyph and optional wordmark
- swap the header image for the Logo component, adjust metadata, and refresh README references to the SVG asset
- provide the new vector logo asset for consistent branding across the site

## Testing
- npx eslint .

------
https://chatgpt.com/codex/tasks/task_e_68d429577c448327ba700dd6ffb1f784